### PR TITLE
Implement conditional page rendering based on role

### DIFF
--- a/backend/src/controllers/user.controller.ts
+++ b/backend/src/controllers/user.controller.ts
@@ -56,7 +56,7 @@ export class UserController {
 
   public login = async (req: Request, res: Response, next: NextFunction) => {
     const { email, password } = req.body
-    const user = await User.checkCredentials(email, password)
+    const user: UserDbType = await User.checkCredentials(email, password)
     if (!user) {
       return res.status(401).json("Invalid email or password")
     }
@@ -68,7 +68,9 @@ export class UserController {
       config.SECRET_KEY,
       { expiresIn: config.TTL }
     )
-    res.status(200).json({ data: { token }, message: "Logged in" })
+    res
+      .status(200)
+      .json({ data: { token, role: user.role }, message: "Logged in" })
   }
 
   public updateUser = async (

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,9 +8,9 @@ import { AuthProvider } from "./hooks/useAuth"
 import Grateful from "./pages/Grateful"
 import Homepage from "./pages/Homepage"
 import Landingpage from "./pages/Landingpage"
+import LoginPage from "./pages/LoginPage"
 import Mood from "./pages/Mood"
 import SignupPage from "./pages/SignupPage"
-import LoginPage from "./pages/LoginPage"
 
 function App() {
   return (
@@ -45,14 +45,7 @@ function App() {
             }
           />
           <Route path="/401" element={<Unauthorised />} />
-          <Route
-            path="/*"
-            element={
-              <ProtectedRoute>
-                <NotFound />
-              </ProtectedRoute>
-            }
-          />
+          <Route path="/*" element={<NotFound />} />
         </Routes>
       </BrowserRouter>
     </AuthProvider>

--- a/frontend/src/components/error/Unauthorised/Unauthorised.js
+++ b/frontend/src/components/error/Unauthorised/Unauthorised.js
@@ -6,7 +6,10 @@ const Unauthorised = () => {
   return (
     <div>
       <h1>401 - Unauthorised</h1>
-      <p>You must be logged in to view this page.</p>
+      <p>
+        You are not authorised to view this page. Sign up or log in with an
+        appropriate account to continue.
+      </p>
       <button onClick={() => navigate("/login")}>Log in</button>
       <button onClick={() => navigate("/signup")}>Sign up</button>
     </div>

--- a/frontend/src/components/public/Login/Login.js
+++ b/frontend/src/components/public/Login/Login.js
@@ -14,7 +14,7 @@ const Login = () => {
     try {
       const response = await loginUser({ email, password })
       if (response) {
-        login(response.data.token)
+        login(response.data)
         setMessage("User logged in successfully")
       }
     } catch (error) {

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -4,23 +4,24 @@ import { useLocalStorage } from "./useLocalStorage"
 const AuthContext = createContext(null)
 
 export const AuthProvider = ({ children }) => {
-  const [token, setToken] = useLocalStorage("token", null)
+  const [authData, setAuthData] = useLocalStorage("authData", null)
 
   const login = async (data) => {
-    setToken(data)
+    setAuthData(data)
   }
 
   const logout = () => {
-    setToken(null)
+    setAuthData(null)
   }
 
   const value = useMemo(
     () => ({
-      token,
+      token: authData?.token,
+      role: authData?.role,
       login,
       logout,
     }),
-    [token]
+    [authData]
   )
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/frontend/src/pages/Grateful.js
+++ b/frontend/src/pages/Grateful.js
@@ -1,17 +1,15 @@
-import React from 'react'
-import Navbar from '../components/Navbar'
-import GratefulHeader from '../components/Grateful/GratefulHeader'
-import GratefulItem from '../components/Grateful/GratefulItem'
-import '../styles/Grateful/Grateful.css'
+import PatientGrateful from "./Patient/PatientGrateful"
+import { useAuth } from "../hooks/useAuth"
+import { Navigate } from "react-router-dom"
 
 function Grateful() {
-  return (
-    <div className='Grateful'>
-      <Navbar/>
-      <GratefulHeader/>
-      <GratefulItem/>
-    </div>
-  )
+  const { role } = useAuth()
+
+  if (role === "Patient") {
+    return <PatientGrateful />
+  }
+
+  return <Navigate to="/401" />
 }
 
 export default Grateful

--- a/frontend/src/pages/Homepage.js
+++ b/frontend/src/pages/Homepage.js
@@ -1,38 +1,17 @@
-import React from 'react'
-import Navbar from '../components/Navbar'
-import Home_Header from '../components/Homepage/Home_Header'
-import Dashboard_Icon from '../components/Homepage/Dashboard_Icon'
-import { useNavigate } from "react-router-dom";
-import '../styles/Homepage/Homepage.css'
+import PatientHomepage from "./Patient/PatientHomepage"
+import TherapistHomepage from "./Therapist/TherapistHomepage"
+import { useAuth } from "../hooks/useAuth"
 
 function Homepage() {
+  const { role } = useAuth()
 
-    const navigate = useNavigate();
-    const moodHandler = () => {
-        navigate('/mood');
-    }
+  if (role === "Therapist") {
+    return <TherapistHomepage />
+  } else if (role === "Patient") {
+    return <PatientHomepage />
+  }
 
-    const gratefulHandler = () => {
-        navigate('/grateful');
-    }
-
-  return (
-    <>
-        <Navbar/>
-        {/* to change test and number to user info */}
-        <Home_Header name='test' streak='number'/> 
-        <div className='dashboard'>
-            <div className='dashboard-top'>
-                <Dashboard_Icon onClick={moodHandler} text='mood'/>
-                <Dashboard_Icon onClick={gratefulHandler} text='grateful'/>
-            </div>
-            <div className='dashboard-bottom'>
-                <Dashboard_Icon text='video call'/>
-                <Dashboard_Icon text='resources'/>
-            </div>
-        </div>
-    </>
-  )
+  return <div>test</div>
 }
 
 export default Homepage

--- a/frontend/src/pages/Homepage.js
+++ b/frontend/src/pages/Homepage.js
@@ -1,6 +1,6 @@
+import { useAuth } from "../hooks/useAuth"
 import PatientHomepage from "./Patient/PatientHomepage"
 import TherapistHomepage from "./Therapist/TherapistHomepage"
-import { useAuth } from "../hooks/useAuth"
 
 function Homepage() {
   const { role } = useAuth()
@@ -10,8 +10,6 @@ function Homepage() {
   } else if (role === "Patient") {
     return <PatientHomepage />
   }
-
-  return <div>test</div>
 }
 
 export default Homepage

--- a/frontend/src/pages/Mood.js
+++ b/frontend/src/pages/Mood.js
@@ -1,38 +1,15 @@
-import React from 'react'
-import Navbar from '../components/Navbar'
-import Mood_Header from '../components/Mood/Mood_Header'
-import Mood_Button from '../components/Mood/Mood_Button'
-import '../styles/Mood/Mood.css'
-import { useState } from 'react'
-import MoodConfirmButton from '../components/Mood/MoodConfirmButton'
+import PatientMood from "./Patient/PatientMood"
+import { useAuth } from "../hooks/useAuth"
+import { Navigate } from "react-router-dom"
 
 function Mood() {
+  const { role } = useAuth()
 
-  const [selectedMood, setSelectedMood] = useState(null);
-  const moodButtonHandler = (mood) => {
-    setSelectedMood(mood);
+  if (role === "Patient") {
+    return <PatientMood />
   }
 
-  return (
-    <div className='Mood'>
-        <Navbar/>
-        <Mood_Header/>
-        <div className='mood-buttons'>
-            <Mood_Button mood='HAPPY' isSelected={selectedMood == 'HAPPY'} onClick={() => moodButtonHandler('HAPPY')}/>
-            <Mood_Button mood='EXCITED' isSelected={selectedMood == 'EXCITED'} onClick={() => moodButtonHandler('EXCITED')}/>
-            <Mood_Button mood='SAD' isSelected={selectedMood == 'SAD'} onClick={() => moodButtonHandler('SAD')}/>
-            <Mood_Button mood='DISAPPOINTED' isSelected={selectedMood == 'DISAPPOINTED'} onClick={() => moodButtonHandler('DISAPPOINTED')}/>
-            <Mood_Button mood='OKAY' isSelected={selectedMood == 'OKAY'} onClick={() => moodButtonHandler('OKAY')}/>
-            <Mood_Button mood='GRATEFUL' isSelected={selectedMood == 'GRATEFUL'} onClick={() => moodButtonHandler('GRATEFUL')}/>
-            <Mood_Button mood='ANGRY' isSelected={selectedMood == 'ANGRY'} onClick={() => moodButtonHandler('ANGRY')}/>
-            <Mood_Button mood='LONELY' isSelected={selectedMood == 'LONELY'} onClick={() => moodButtonHandler('LONELY')}/>
-            <Mood_Button mood='HOPEFUL' isSelected={selectedMood == 'HOPEFUL'} onClick={() => moodButtonHandler('HOPEFUL')}/>
-            <Mood_Button mood='ANXIOUS' isSelected={selectedMood == 'ANXIOUS'} onClick={() => moodButtonHandler('ANXIOUS')}/>
-            <Mood_Button mood='RELAXED' isSelected={selectedMood == 'RELAXED'} onClick={() => moodButtonHandler('RELAXED')}/>
-        </div>
-        <MoodConfirmButton/>
-    </div>
-  )
+  return <Navigate to="/401" />
 }
 
 export default Mood

--- a/frontend/src/pages/Patient/PatientGrateful.js
+++ b/frontend/src/pages/Patient/PatientGrateful.js
@@ -1,0 +1,16 @@
+import GratefulHeader from "../../components/Grateful/GratefulHeader"
+import GratefulItem from "../../components/Grateful/GratefulItem"
+import Navbar from "../../components/Navbar"
+import "../../styles/Grateful/Grateful.css"
+
+function PatientGrateful() {
+  return (
+    <div className="Grateful">
+      <Navbar />
+      <GratefulHeader />
+      <GratefulItem />
+    </div>
+  )
+}
+
+export default PatientGrateful

--- a/frontend/src/pages/Patient/PatientHomepage.js
+++ b/frontend/src/pages/Patient/PatientHomepage.js
@@ -1,0 +1,37 @@
+import React from "react"
+import { useNavigate } from "react-router-dom"
+import Dashboard_Icon from "../../components/Homepage/Dashboard_Icon"
+import Home_Header from "../../components/Homepage/Home_Header"
+import Navbar from "../../components/Navbar"
+import "../../styles/Homepage/Homepage.css"
+
+function PatientHomepage() {
+  const navigate = useNavigate()
+  const moodHandler = () => {
+    navigate("/mood")
+  }
+
+  const gratefulHandler = () => {
+    navigate("/grateful")
+  }
+
+  return (
+    <>
+      <Navbar />
+      {/* to change test and number to user info */}
+      <Home_Header name="test" streak="number" />
+      <div className="dashboard">
+        <div className="dashboard-top">
+          <Dashboard_Icon onClick={moodHandler} text="mood" />
+          <Dashboard_Icon onClick={gratefulHandler} text="grateful" />
+        </div>
+        <div className="dashboard-bottom">
+          <Dashboard_Icon text="video call" />
+          <Dashboard_Icon text="resources" />
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default PatientHomepage

--- a/frontend/src/pages/Patient/PatientMood.js
+++ b/frontend/src/pages/Patient/PatientMood.js
@@ -1,0 +1,80 @@
+import { useState } from "react"
+import MoodConfirmButton from "../../components/Mood/MoodConfirmButton"
+import Mood_Button from "../../components/Mood/Mood_Button"
+import Mood_Header from "../../components/Mood/Mood_Header"
+import Navbar from "../../components/Navbar"
+import "../../styles/Mood/Mood.css"
+
+function PatientMood() {
+  const [selectedMood, setSelectedMood] = useState(null)
+  const moodButtonHandler = (mood) => {
+    setSelectedMood(mood)
+  }
+
+  return (
+    <div className="Mood">
+      <Navbar />
+      <Mood_Header />
+      <div className="mood-buttons">
+        <Mood_Button
+          mood="HAPPY"
+          isSelected={selectedMood == "HAPPY"}
+          onClick={() => moodButtonHandler("HAPPY")}
+        />
+        <Mood_Button
+          mood="EXCITED"
+          isSelected={selectedMood == "EXCITED"}
+          onClick={() => moodButtonHandler("EXCITED")}
+        />
+        <Mood_Button
+          mood="SAD"
+          isSelected={selectedMood == "SAD"}
+          onClick={() => moodButtonHandler("SAD")}
+        />
+        <Mood_Button
+          mood="DISAPPOINTED"
+          isSelected={selectedMood == "DISAPPOINTED"}
+          onClick={() => moodButtonHandler("DISAPPOINTED")}
+        />
+        <Mood_Button
+          mood="OKAY"
+          isSelected={selectedMood == "OKAY"}
+          onClick={() => moodButtonHandler("OKAY")}
+        />
+        <Mood_Button
+          mood="GRATEFUL"
+          isSelected={selectedMood == "GRATEFUL"}
+          onClick={() => moodButtonHandler("GRATEFUL")}
+        />
+        <Mood_Button
+          mood="ANGRY"
+          isSelected={selectedMood == "ANGRY"}
+          onClick={() => moodButtonHandler("ANGRY")}
+        />
+        <Mood_Button
+          mood="LONELY"
+          isSelected={selectedMood == "LONELY"}
+          onClick={() => moodButtonHandler("LONELY")}
+        />
+        <Mood_Button
+          mood="HOPEFUL"
+          isSelected={selectedMood == "HOPEFUL"}
+          onClick={() => moodButtonHandler("HOPEFUL")}
+        />
+        <Mood_Button
+          mood="ANXIOUS"
+          isSelected={selectedMood == "ANXIOUS"}
+          onClick={() => moodButtonHandler("ANXIOUS")}
+        />
+        <Mood_Button
+          mood="RELAXED"
+          isSelected={selectedMood == "RELAXED"}
+          onClick={() => moodButtonHandler("RELAXED")}
+        />
+      </div>
+      <MoodConfirmButton />
+    </div>
+  )
+}
+
+export default PatientMood

--- a/frontend/src/pages/Therapist/TherapistHomepage.js
+++ b/frontend/src/pages/Therapist/TherapistHomepage.js
@@ -1,0 +1,5 @@
+const TherapistHomepage = () => {
+  return <div>therapist home page placeholder</div>
+}
+
+export default TherapistHomepage

--- a/frontend/src/utils/private/invokeBackend.js
+++ b/frontend/src/utils/private/invokeBackend.js
@@ -1,0 +1,18 @@
+import axios from "axios"
+import { BACKEND_URI } from "../../config/env.config"
+
+const token = localStorage.getItem("token")
+let newToken
+
+if (token) {
+  newToken = token.substring(1, token.length - 1)
+}
+
+export const getUsers = async () => {
+  const response = await axios.get(`${BACKEND_URI}/users`, {
+    headers: {
+      Authorization: `Bearer ${newToken}`,
+    },
+  })
+  return response.data
+}


### PR DESCRIPTION
# PR Summary

- Added `role` to the response body of the POST `/users/login` route. Response looks like this:

```json
{
    "data": {
        "token": "jwt token",
        "role": "Therapist" (or Patient)
    },
    "message": "Logged in"
}
```

- Separated pages in frontend based on this `role`. Example, `Homepage.js` looks like this:

```
function Homepage() {
  const { role } = useAuth()

  if (role === "Therapist") {
    return <TherapistHomepage />
  } else if (role === "Patient") {
    return <PatientHomepage />
  }
}
```

In other words, therapists will see the `TherapistHomepage` component while patients will see the `PatientHomepage` component. For routes that should only be accessible to a certain role (only Patient or only Therapist), they will look something like this:

```
function Grateful() {
  const { role } = useAuth()

  if (role === "Patient") {
    return <PatientGrateful />
  }

  return <Navigate to="/401" />
}
```

Here, the /grateful frontend route will only be accessible by Patients.